### PR TITLE
Improve Telegram bot debug logging

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -4,7 +4,13 @@ import { env } from './env.js';
 
 export function checkTelegramHeader(req: Request, res: Response, next: NextFunction) {
   const token = req.get('X-Telegram-Bot-Api-Secret-Token');
+  if (!token) {
+    console.warn('⚠️ Missing X-Telegram-Bot-Api-Secret-Token header');
+    res.status(403).end();
+    return;
+  }
   if (token !== env.TELEGRAM_SECRET_TOKEN) {
+    console.warn(`⚠️ Invalid Telegram secret token: ${token}`);
     res.status(403).end();
     return;
   }


### PR DESCRIPTION
## Summary
- Fix `/start` reply markup using `keyboard` property and correct structure
- Log and surface errors from Telegram API calls and callback query answers
- Warn on missing or invalid `X-Telegram-Bot-Api-Secret-Token` headers

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc1fbba274832683d294eac001afd7