### PR TITLE
feat: add error logging for Telegram sendMessage failures

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,11 +7,19 @@ async function sendMessage(chatId: number, text: string, keyboard?: any) {
   const body: any = { chat_id: chatId, text, parse_mode: 'HTML' };
   if (keyboard) body.reply_markup = keyboard;
   console.debug('➡️ Sending message payload:', JSON.stringify(body));
-  const res = await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
+  let res;
+  try {
+    res = await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('❌ Error sending message:', message);
+    console.error('➡️ Failed payload:', JSON.stringify(body));
+    throw error;
+  }
   if (!res.ok) {
     const err = await res.text();
     console.error(`❌ Telegram API error ${res.status}: ${err}`);


### PR DESCRIPTION
## Summary
- handle sendMessage failures by wrapping fetch in try/catch
- log exception message and payload when Telegram request fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc37bb3fa08326af223b29880e0657