### PR TITLE
feat: add webhook debug report

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,28 @@ import { handleUpdate } from './server.js';
 import { checkTelegramHeader } from './security.js';
 import { fetch } from 'undici';
 
+// in-memory log buffer
+const logs: string[] = [];
+function pushLog(level: string, args: any[]) {
+  logs.push(`${new Date().toISOString()} [${level}] ${args.join(' ')}`);
+  if (logs.length > 100) logs.shift();
+}
+const originalLog = console.log;
+console.log = (...args: any[]) => {
+  pushLog('log', args);
+  originalLog(...args);
+};
+const originalError = console.error;
+console.error = (...args: any[]) => {
+  pushLog('error', args);
+  originalError(...args);
+};
+const originalWarn = console.warn;
+console.warn = (...args: any[]) => {
+  pushLog('warn', args);
+  originalWarn(...args);
+};
+
 const app = express();
 app.use(express.json());
 
@@ -19,7 +41,7 @@ if (webhookPath) {
   });
 }
 
-app.get('/debug', (req, res) => {
+app.get('/debug', async (req, res) => {
   const auth = req.headers.authorization;
   const expected = 'Basic ' + Buffer.from(`admin:${env.ADMIN_KEY}`).toString('base64');
   if (auth !== expected) {
@@ -27,7 +49,32 @@ app.get('/debug', (req, res) => {
     res.status(401).end();
     return;
   }
-  res.send('<h1>Debug</h1>');
+
+  const webhookUrl = env.PUBLIC_BASE_URL && env.WEBHOOK_PATH_SECRET
+    ? `${env.PUBLIC_BASE_URL}/telegram/${env.WEBHOOK_PATH_SECRET}`
+    : undefined;
+
+  let webhookInfo: any;
+  try {
+    const r = await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/getWebhookInfo`);
+    webhookInfo = await r.json();
+  } catch (e) {
+    const err = e as Error;
+    webhookInfo = { ok: false, error: err.message };
+  }
+
+  res.json({
+    webhookUrl,
+    webhookInfo,
+    env: {
+      PUBLIC_BASE_URL: mask(env.PUBLIC_BASE_URL),
+      WEBHOOK_PATH_SECRET: mask(env.WEBHOOK_PATH_SECRET),
+      TELEGRAM_BOT_TOKEN: mask(env.TELEGRAM_BOT_TOKEN),
+      TELEGRAM_SECRET_TOKEN: mask(env.TELEGRAM_SECRET_TOKEN),
+      ADMIN_KEY: mask(env.ADMIN_KEY),
+    },
+    logs: logs.slice(-20),
+  });
 });
 
 app.listen(env.PORT, () => {


### PR DESCRIPTION
## Summary
- add in-memory log buffer and capture console output
- extend debug endpoint to show webhook info, masked env vars, and logs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc383a2b5883268ebc7eddb53f3aac